### PR TITLE
Update Ripple.ArrayHandler.xml

### DIFF
--- a/Cache/Ripple.ArrayHandler.xml
+++ b/Cache/Ripple.ArrayHandler.xml
@@ -20,7 +20,7 @@ Array Handling utility class written by Mike Clayton for:<br />
  |                                                                          |
  | Copyright (c) 2016 Ripple Foundation Community Interest Company          |
  |                                                                          |
- | Copyright (c) 2017 M/Gateway Ltd                                         |
+ | Copyright (c) 2017 Mike Clayton                                        |
  |                                                                          |
  |                                                                          |
  | Licensed under the Apache License, Version 2.0 (the "License");          |


### PR DESCRIPTION
update on transfer (including copyright) of these works
Original copyright was to Ripple Foundation CIC
Copyright transferred to Mike Clayton in June 2017
Same Apache 2 License applies

After further discussion, code transferred from Ripple Foundation github org a/c via Tony Shannon individual a/c to Mike Clayton
Mike is planning to further improve this work, while maintaining it as open source tool publicly available under Apache2

Dr Tony Shannon, Director, Ripple Foundation, 27 June 2017